### PR TITLE
3 merge top

### DIFF
--- a/jeeves_pr_stack/app.py
+++ b/jeeves_pr_stack/app.py
@@ -5,10 +5,13 @@ from rich.style import Style
 from rich.table import Table
 from rich.text import Text
 from sh import gh
-from typer import Typer, Context, Exit
+from typer import Typer, Exit
 
 from jeeves_pr_stack import github
-from jeeves_pr_stack.models import ChecksStatus, PullRequest, State
+from jeeves_pr_stack.models import (
+    ChecksStatus, PullRequest, State,
+    PRStackContext,
+)
 
 app = Typer(
     help='Manage stacks of GitHub PRs.',
@@ -104,7 +107,7 @@ def _print_stack(stack: list[PullRequest]):
 
 
 @app.callback()
-def print_current_stack(context: Context):
+def print_current_stack(context: PRStackContext):
     """Print current PR stack."""
     current_branch = github.retrieve_current_branch()
     stack = github.retrieve_stack(current_branch=current_branch)
@@ -133,9 +136,9 @@ def rebase():
 
 
 @app.command()
-def merge():
+def merge(context: PRStackContext):
     """Merge current stack, starting from the top."""
-    raise NotImplementedError()
+
 
 
 @app.command()
@@ -153,10 +156,10 @@ def split():
 
 
 @app.command()
-def append(context: Context):
+def append(context: PRStackContext):
     """Direct current branch/PR to an existing PR."""
     console = Console()
-    state: State = context.obj
+    state = context.obj
 
     if state.stack:
         console.print(

--- a/jeeves_pr_stack/app.py
+++ b/jeeves_pr_stack/app.py
@@ -1,8 +1,5 @@
-import time
-
 import funcy
 from rich.console import Console, RenderableType
-from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.prompt import Prompt
 from rich.style import Style
 from rich.table import Table
@@ -190,6 +187,9 @@ def append(context: PRStackContext):   # noqa: WPS210
     pull_requests = github.retrieve_pull_requests_to_append(
         current_branch=state.current_branch,
     )
+
+    if not pull_requests:
+        raise ValueError('No PRs found which this branch could refer to.')
 
     _print_stack(pull_requests)
 

--- a/jeeves_pr_stack/app.py
+++ b/jeeves_pr_stack/app.py
@@ -83,13 +83,6 @@ def _print_stack(stack: list[PullRequest]):
             style=Style(color='magenta'),
         )
 
-        if is_top_pr:
-            heading.append('Top PR', style=Style(
-                bold=True,
-                reverse=True,
-            ))
-            heading.append(' Start merging the stack from here.\n')
-
         table.add_row(
             is_current,
             str(pr.number),
@@ -126,7 +119,10 @@ def print_current_stack(context: PRStackContext):
         '∅ No PRs associated with current branch.\n',
         style=Style(color='white', bold=True),
     )
-    console.print('Use [code]gh pr create[/code] to create one.')
+    console.print('• Use [code]gh pr create[/code] to create one,')
+    console.print(
+        '• Or [code]j stack append[/code] to stack it onto another PR.',
+    )
 
 
 @app.command()

--- a/jeeves_pr_stack/app.py
+++ b/jeeves_pr_stack/app.py
@@ -61,9 +61,8 @@ def _print_stack(stack: list[PullRequest]):
         box=None,
     )
 
-    for index, pr in enumerate(stack):
+    for pr in stack:
         is_current = '➤' if pr.is_current else ''
-        is_top_pr = (index == 0)
 
         heading = Text()
         heading.append(
@@ -136,12 +135,9 @@ def merge(context: PRStackContext):
     """Merge current stack, starting from the top."""
 
 
-
 @app.command()
 def comment():
-    """
-    Add or update a comment with a navigation table to each PR in current stack.
-    """
+    """Comment on each PR of current stack with a navigation table."""
     raise NotImplementedError()
 
 
@@ -152,7 +148,7 @@ def split():
 
 
 @app.command()
-def append(context: PRStackContext):
+def append(context: PRStackContext):   # noqa: WPS210
     """Direct current branch/PR to an existing PR."""
     console = Console()
     state = context.obj

--- a/jeeves_pr_stack/github.py
+++ b/jeeves_pr_stack/github.py
@@ -1,6 +1,7 @@
 import json
 import operator
 import os
+from typing import Iterable
 
 import funcy
 from networkx import DiGraph, edge_dfs
@@ -75,6 +76,13 @@ def retrieve_current_branch() -> str:
     return git.branch('--show-current').strip()
 
 
+def _construct_gh_env() -> dict[str, str]:
+    return {
+        **os.environ,
+        'NO_COLOR': '1',
+    }
+
+
 def retrieve_pull_requests(current_branch: str) -> list[PullRequest]:
     """
     Retrieve a list of all open PRs in the repo.
@@ -98,10 +106,7 @@ def retrieve_pull_requests(current_branch: str) -> list[PullRequest]:
     raw_pull_requests: list[RawPullRequest] = json.loads(
         gh.pr.list(
             json=','.join(fields),
-            _env={
-                **os.environ,
-                'NO_COLOR': '1',
-            },
+            _env=_construct_gh_env(),
         ),
     )
 
@@ -151,3 +156,12 @@ def retrieve_pull_requests_to_append(current_branch: str) -> list[PullRequest]:
         key=operator.attrgetter('number'),
         reverse=True,
     )
+
+
+def retrieve_default_branch() -> str:
+    return json.loads(
+        gh.repo.view(
+            json='defaultBranchRef',
+            _env=_construct_gh_env(),
+        ),
+    )['defaultBranchRef']['name']

--- a/jeeves_pr_stack/github.py
+++ b/jeeves_pr_stack/github.py
@@ -71,10 +71,16 @@ def construct_stack_for_branch(   # noqa: WPS210
 
 
 def retrieve_current_branch() -> str:
+    """Retrieve current git branch name."""
     return git.branch('--show-current').strip()
 
 
 def retrieve_pull_requests(current_branch: str) -> list[PullRequest]:
+    """
+    Retrieve a list of all open PRs in the repo.
+
+    Mark the one bound to current branch with `is_current` field.
+    """
     fields = [
         'number',
         'baseRefName',
@@ -136,7 +142,12 @@ def retrieve_pull_requests_to_append(current_branch: str) -> list[PullRequest]:
         for pr in pull_requests
     }
 
-    return sorted([
-        pr
-        for pr in pull_requests if directed_to.get(pr.branch) is None
-    ], key=operator.attrgetter('number'), reverse=True)
+    return sorted(
+        [
+            pr
+            for pr in pull_requests
+            if directed_to.get(pr.branch) is None
+        ],
+        key=operator.attrgetter('number'),
+        reverse=True,
+    )

--- a/jeeves_pr_stack/github.py
+++ b/jeeves_pr_stack/github.py
@@ -159,6 +159,7 @@ def retrieve_pull_requests_to_append(current_branch: str) -> list[PullRequest]:
 
 
 def retrieve_default_branch() -> str:
+    """Get default branch of current repository."""
     return json.loads(
         gh.repo.view(
             json='defaultBranchRef',

--- a/jeeves_pr_stack/models.py
+++ b/jeeves_pr_stack/models.py
@@ -79,7 +79,7 @@ StateType = TypeVar('StateType')
 class TypedContext(Context, Generic[StateType]):
     """Typed context."""
 
-    obj: StateType
+    obj: StateType   # noqa: WPS110
 
 
 class PRStackContext(TypedContext[State]):

--- a/jeeves_pr_stack/models.py
+++ b/jeeves_pr_stack/models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import TypedDict, Generic, TypeVar, NamedTuple
+from typing import TypedDict, Generic, TypeVar
 
 from typer import Context
 
@@ -65,6 +65,7 @@ class PullRequest:
     checks_status: ChecksStatus
 
     def __repr__(self):
+        """Represent a PR for printing."""
         return (
             f'#{self.number} {self.title} | {self.branch} → {self.base_branch}'
         )

--- a/jeeves_pr_stack/models.py
+++ b/jeeves_pr_stack/models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import TypedDict, Generic, TypeVar
+from typing import TypedDict, Generic, TypeVar, NamedTuple
 
 from typer import Context
 
@@ -63,6 +63,11 @@ class PullRequest:
     is_draft: bool
     reviewers: list[str]
     checks_status: ChecksStatus
+
+    def __repr__(self):
+        return (
+            f'#{self.number} {self.title} | {self.branch} → {self.base_branch}'
+        )
 
 
 @dataclass

--- a/jeeves_pr_stack/models.py
+++ b/jeeves_pr_stack/models.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import TypedDict
+from typing import TypedDict, Generic, TypeVar
+
+from typer import Context
 
 
 class RawReviewRequest(TypedDict):
@@ -69,3 +71,16 @@ class State:
 
     current_branch: str
     stack: list[PullRequest]
+
+
+StateType = TypeVar('StateType')
+
+
+class TypedContext(Context, Generic[StateType]):
+    """Typed context."""
+
+    obj: StateType
+
+
+class PRStackContext(TypedContext[State]):
+    """Typed context for Jeeves PR Stack app."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,16 +26,6 @@ files = [
 ]
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-description = "Atomic file writes."
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
-]
-
-[[package]]
 name = "attrs"
 version = "23.1.0"
 description = "Classes Without Boilerplate"
@@ -293,6 +283,9 @@ files = [
     {file = "coverage-7.3.1.tar.gz", hash = "sha256:6cb7fe1581deb67b782c153136541e20901aa312ceedaf1467dcb35255787952"},
 ]
 
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
 [package.extras]
 toml = ["tomli"]
 
@@ -391,6 +384,20 @@ files = [
     {file = "eradicate-2.3.0-py3-none-any.whl", hash = "sha256:2b29b3dd27171f209e4ddd8204b70c02f0682ae95eecb353f10e8d72b149c63e"},
     {file = "eradicate-2.3.0.tar.gz", hash = "sha256:06df115be3b87d0fc1c483db22a2ebb12bcf40585722810d809cc770f5031c37"},
 ]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.1.3"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "flake8"
@@ -676,13 +683,13 @@ files = [
 
 [[package]]
 name = "funcy"
-version = "1.18"
+version = "2.0"
 description = "A fancy and practical functional tools"
 optional = false
 python-versions = "*"
 files = [
-    {file = "funcy-1.18-py2.py3-none-any.whl", hash = "sha256:00ce91afc850357a131dc54f0db2ad8a1110d5087f1fa4480d7ea3ba0249f89d"},
-    {file = "funcy-1.18.tar.gz", hash = "sha256:15448d19a8ebcc7a585afe7a384a19186d0bd67cbf56fb42cd1fd0f76313f9b2"},
+    {file = "funcy-2.0-py2.py3-none-any.whl", hash = "sha256:53df23c8bb1651b12f095df764bfb057935d49537a56de211b098f4c79614bb0"},
+    {file = "funcy-2.0.tar.gz", hash = "sha256:3963315d59d41c6f30c04bc910e10ab50a3ac4a225868bfa96feed133df075cb"},
 ]
 
 [[package]]
@@ -754,13 +761,13 @@ files = [
 
 [[package]]
 name = "iolanta"
-version = "1.0.18"
+version = "1.0.19"
 description = "Semantic Web browser"
 optional = false
 python-versions = ">=3.10,<4.0"
 files = [
-    {file = "iolanta-1.0.18-py3-none-any.whl", hash = "sha256:057cde86ce3ee4913ebf5ad3c2ee68bbe091abd56e782fcbbf642b1d436c40d0"},
-    {file = "iolanta-1.0.18.tar.gz", hash = "sha256:3a232485bf4f1c662c193a2492eaf2be1287be0a2a4d6270f1d8296d5f47a4f1"},
+    {file = "iolanta-1.0.19-py3-none-any.whl", hash = "sha256:e256ddcfeabbda286e32adaeacadbfda5cf99dea78f9546424f9a57bb821a82f"},
+    {file = "iolanta-1.0.19.tar.gz", hash = "sha256:a9830f4403c051538c1199cd79cb44290882a4d201598988192c6ba156823e11"},
 ]
 
 [package.dependencies]
@@ -768,7 +775,7 @@ classes = ">=0.4.0,<0.5.0"
 deepmerge = ">=0.1.1,<0.2.0"
 documented = ">=0.1.1,<0.2.0"
 dominate = ">=2.6.0,<3.0.0"
-funcy = ">=1.17,<2.0"
+funcy = ">=2.0,<3.0"
 more-itertools = ">=9.0.0,<10.0.0"
 owlrl = ">=6.0.2,<7.0.0"
 PyLD = ">=2.0.3,<3.0.0"
@@ -827,18 +834,18 @@ requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "jeeves-shell"
-version = "2.3.0"
+version = "2.3.1"
 description = "Pythonic replacement for GNU Make"
 optional = false
 python-versions = ">=3.10,<4.0"
 files = [
-    {file = "jeeves_shell-2.3.0-py3-none-any.whl", hash = "sha256:f9e3a3cf41faf226ebfc4c8cb01dcb0c793f780e736ef1137661b45ab5f062be"},
-    {file = "jeeves_shell-2.3.0.tar.gz", hash = "sha256:1e70340efb1b58d51efee63e96231ef092ccb7d13f5c178426c17e2ac613c259"},
+    {file = "jeeves_shell-2.3.1-py3-none-any.whl", hash = "sha256:21e8a3872ae59bf8dce64bf805ac42c1d7eda5ffd4b4dd36c2ee6c9c6c8c6887"},
+    {file = "jeeves_shell-2.3.1.tar.gz", hash = "sha256:0183a41c6722601cee17d04bd49d072b7118ad7ca1ef0150ddd1bbafc50de40d"},
 ]
 
 [package.dependencies]
 documented = ">=0.1.1,<0.2.0"
-more-itertools = ">=9.0.0,<10.0.0"
+funcy = ">=2.0,<3.0"
 rich = {version = ">=13.3.5,<14.0.0", optional = true, markers = "extra == \"all\""}
 sh = {version = ">=2.0.4,<3.0.0", optional = true, markers = "extra == \"all\""}
 typer = ">=0.9.0,<0.10.0"
@@ -848,13 +855,13 @@ all = ["rich (>=13.3.5,<14.0.0)", "sh (>=2.0.4,<3.0.0)"]
 
 [[package]]
 name = "jeeves-yeti-pyproject"
-version = "0.2.21"
+version = "0.2.23"
 description = "Opinionated Jeeves plugin for Python projects."
 optional = false
 python-versions = ">=3.10,<4.0"
 files = [
-    {file = "jeeves_yeti_pyproject-0.2.21-py3-none-any.whl", hash = "sha256:23647c1149ab5b5c0ebcc51a5cb33577625ed454a1bd12ed22224d5c6d355d76"},
-    {file = "jeeves_yeti_pyproject-0.2.21.tar.gz", hash = "sha256:079304c23b43afbf261e595b21337114cd449a63c282acb7db8b9d046e7b039f"},
+    {file = "jeeves_yeti_pyproject-0.2.23-py3-none-any.whl", hash = "sha256:0287ef7cf7b55f3a7573c7a6b6c0ee4343641aa6202aa9649b7f07219d5c1cf0"},
+    {file = "jeeves_yeti_pyproject-0.2.23.tar.gz", hash = "sha256:c2f2d6fbfc091223b6fdc13d9cf51d7f2332246d55874062a7a0265174b70a1d"},
 ]
 
 [package.dependencies]
@@ -866,8 +873,8 @@ mkdocs-iolanta = ">=0.1.0,<0.2.0"
 mkdocs-macros-plugin = ">=0.7.0,<0.8.0"
 mkdocs-material = ">=9.0.3,<10.0.0"
 mypy = ">=0.910,<0.911"
-pytest = ">=6.2,<7.0"
-pytest-cov = ">=2.12,<3.0"
+pytest = ">=7.4.2,<8.0.0"
+pytest-cov = ">=4.1.0,<5.0.0"
 pytest-randomly = ">=3.8,<4.0"
 rich = ">=13.3.1,<14.0.0"
 safety = ">=1.10,<2.0"
@@ -1065,6 +1072,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -1415,17 +1432,6 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
-name = "py"
-version = "1.11.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
-    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
-]
-
-[[package]]
 name = "pycodestyle"
 version = "2.8.0"
 description = "Python style guide checker"
@@ -1533,43 +1539,40 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "6.2.5"
+version = "7.4.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
-    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+    {file = "pytest-7.4.2-py3-none-any.whl", hash = "sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002"},
+    {file = "pytest-7.4.2.tar.gz", hash = "sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069"},
 ]
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-py = ">=1.8.2"
-toml = "*"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
-version = "2.12.1"
+version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
-    {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
+    {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
+    {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
 ]
 
 [package.dependencies]
-coverage = ">=5.2.1"
+coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
-toml = "*"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 
-[tool.flakeheaven.exceptions."jeeves_gh_stack/models.py"]
+[tool.flakeheaven.exceptions."jeeves_pr_stack/models.py"]
 wemake-python-styleguide = [
     "-WPS115",  # TypedDicts describing GH CLI output need CamelCase field names
 ]


### PR DESCRIPTION
- Introduce `PullRequestStatus`
- Table title
- Print two active PRs in the current stack
- Encapsulate retrieval to `github.py`
- Restyle the table
- Show PR number in output
- Less visual noise
- Update deps
- Add `networkx`
- Use DFS and make output nicer
- Refactor Typer callback function
- Refactor `retrieve_stack`
- Most linter errors fixed
- Stabilize sorting
- Indicate top PR
- Prototypes for more commands
- Prototype for `j stack fork`
- `fork` → `append`
- Refactor `retrieve_stack`
- Implement `j append`
- Update dependencies
- Introduce `PRStackContext` class
- Adjust some prints
- Make `j lint` happy
- Draft for `merge-top-pr`
