### PR TITLE
3 ask for confirmation

### DIFF
--- a/jeeves_pr_stack/app.py
+++ b/jeeves_pr_stack/app.py
@@ -6,7 +6,10 @@ from sh import gh, git
 from typer import Typer, Exit
 
 from jeeves_pr_stack import github
-from jeeves_pr_stack.format import pull_request_list_as_table
+from jeeves_pr_stack.format import (
+    pull_request_list_as_table,
+    pull_request_stack_as_table,
+)
 from jeeves_pr_stack.models import (
     State,
     PRStackContext,
@@ -31,8 +34,13 @@ def print_current_stack(context: PRStackContext):
     )
 
     console = Console()
+    default_branch = github.retrieve_default_branch()
     if stack:
-        console.print(pull_request_list_as_table(stack))
+        console.print(pull_request_stack_as_table(
+            stack,
+            default_branch=default_branch,
+            current_branch=current_branch,
+        ))
         return
 
     console.print(

--- a/jeeves_pr_stack/app.py
+++ b/jeeves_pr_stack/app.py
@@ -1,15 +1,14 @@
 import funcy
-from rich.console import Console, RenderableType
+from rich.console import Console
 from rich.prompt import Prompt
 from rich.style import Style
-from rich.table import Table
-from rich.text import Text
 from sh import gh, git
 from typer import Typer, Exit
 
 from jeeves_pr_stack import github
+from jeeves_pr_stack.format import pull_request_list_as_table
 from jeeves_pr_stack.models import (
-    ChecksStatus, PullRequest, State,
+    State,
     PRStackContext,
 )
 
@@ -18,78 +17,6 @@ app = Typer(
     name='stack',
     invoke_without_command=True,
 )
-
-
-def format_status(pr: PullRequest) -> RenderableType:
-    """Format PR status."""
-    if pr.checks_status == ChecksStatus.FAILURE:
-        return Text(
-            '❌ Checks failed',
-            style=Style(color='red'),
-        )
-
-    if pr.review_decision == 'REVIEW_REQUIRED':
-        formatted_reviewers = ', '.join(pr.reviewers)
-        return Text(
-            f'👀 Review required\n{formatted_reviewers}',
-            style=Style(color='yellow'),
-        )
-
-    if pr.is_draft:
-        return Text(
-            '📝 Draft',
-            style=Style(color='bright_black'),
-        )
-
-    return Text(
-        '✅ Ready to merge',
-        style=Style(
-            color='green',
-        ),
-    )
-
-
-def pull_request_list_as_table(stack: list[PullRequest]):
-    table = Table(
-        'Current',
-        'Number',
-        'PR',
-        'Status',
-        show_header=False,
-        show_lines=False,
-        show_edge=False,
-        box=None,
-    )
-
-    for pr in stack:
-        is_current = '➤' if pr.is_current else ''
-
-        heading = Text()
-        heading.append(
-            pr.title,
-            style=Style(link=pr.url, bold=True),
-        )
-        heading.append(
-            f'\n{pr.branch}',
-            style=Style(color='magenta'),
-        )
-        heading.append(
-            ' → ',
-            style=None,
-        )
-        heading.append(
-            f'{pr.base_branch}\n',
-            style=Style(color='magenta'),
-        )
-
-        table.add_row(
-            is_current,
-            str(pr.number),
-            heading,
-            format_status(pr),
-        )
-
-    return table
 
 
 @app.callback()

--- a/jeeves_pr_stack/format.py
+++ b/jeeves_pr_stack/format.py
@@ -1,0 +1,78 @@
+from rich.console import RenderableType
+from rich.style import Style
+from rich.table import Table
+from rich.text import Text
+
+from jeeves_pr_stack.models import PullRequest, ChecksStatus
+
+
+def format_status(pr: PullRequest) -> RenderableType:
+    """Format PR status."""
+    if pr.checks_status == ChecksStatus.FAILURE:
+        return Text(
+            '❌ Checks failed',
+            style=Style(color='red'),
+        )
+
+    if pr.review_decision == 'REVIEW_REQUIRED':
+        formatted_reviewers = ', '.join(pr.reviewers)
+        return Text(
+            f'👀 Review required\n{formatted_reviewers}',
+            style=Style(color='yellow'),
+        )
+
+    if pr.is_draft:
+        return Text(
+            '📝 Draft',
+            style=Style(color='bright_black'),
+        )
+
+    return Text(
+        '✅ Ready to merge',
+        style=Style(
+            color='green',
+        ),
+    )
+
+
+def pull_request_list_as_table(stack: list[PullRequest]):
+    table = Table(
+        'Current',
+        'Number',
+        'PR',
+        'Status',
+        show_header=False,
+        show_lines=False,
+        show_edge=False,
+        box=None,
+    )
+
+    for pr in stack:
+        is_current = '➤' if pr.is_current else ''
+
+        heading = Text()
+        heading.append(
+            pr.title,
+            style=Style(link=pr.url, bold=True),
+        )
+        heading.append(
+            f'\n{pr.branch}',
+            style=Style(color='magenta'),
+        )
+        heading.append(
+            ' → ',
+            style=None,
+        )
+        heading.append(
+            f'{pr.base_branch}\n',
+            style=Style(color='magenta'),
+        )
+
+        table.add_row(
+            is_current,
+            str(pr.number),
+            heading,
+            format_status(pr),
+        )
+
+    return table


### PR DESCRIPTION
- Introduce `PullRequestStatus`
- Table title
- Print two active PRs in the current stack
- Encapsulate retrieval to `github.py`
- Restyle the table
- Show PR number in output
- Less visual noise
- Update deps
- Add `networkx`
- Use DFS and make output nicer
- Refactor Typer callback function
- Refactor `retrieve_stack`
- Most linter errors fixed
- Stabilize sorting
- Indicate top PR
- Prototypes for more commands
- Prototype for `j stack fork`
- `fork` → `append`
- Refactor `retrieve_stack`
- Implement `j append`
- Update dependencies
- Introduce `PRStackContext` class
- Adjust some prints
- Make `j lint` happy
- Draft for `merge-top-pr`
- Fix a number of linter issues
- Rename commands
- Linters are now happy
- Refactor `_print_stack`
- `format.py`
- New rendering style of a PR stack
